### PR TITLE
Disallow .only in frontend tests & Node Upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-- '4.2'
+- '12.18.2'

--- a/frontend-test.js
+++ b/frontend-test.js
@@ -10,6 +10,7 @@ module.exports = {
     },
     "rules": {
         "arrow-body-style": 0,
-        "no-unused-expressions": 0
+        "no-unused-expressions": 0,
+        "no-only-tests/no-only-tests": "error"
     }
 };

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ module.exports = {
       "node": true,
       "mocha": true
     },
+    "plugins": [
+      "no-only-tests"
+    ],
     "rules": {
       // Overrides
       "comma-dangle": 0,

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eslint-config-airbnb": "17.1.0",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jsx-a11y": "6.1.1",
+    "eslint-plugin-no-only-tests": "2.4.0",
     "eslint-plugin-react": "7.11.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
In order to prevent commits with .only in our tests, and avoid it in the future from the damage our production, added an eslint rule to block commits with .only() in frontend tests.
In order to keep the repo updated, upgraded the node version for travis.