### PR TITLE
Enable eslint-jsx-a11y-plugin for all configurations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,16 @@
 module.exports = {
-    "extends": "airbnb",
+    "extends": [
+      "airbnb",
+      "plugin:jsx-a11y/recommended"
+    ],
     "env": {
       "es6": true,
       "node": true,
       "mocha": true
     },
     "plugins": [
-      "no-only-tests"
+      "no-only-tests",
+      "jsx-a11y"
     ],
     "rules": {
       // Overrides
@@ -22,40 +26,6 @@ module.exports = {
       "implicit-arrow-linebreak": 0,
       "import/no-extraneous-dependencies": 0,
       "import/no-unresolved": 0,
-      "jsx-a11y/anchor-has-content": 0,
-      "jsx-a11y/aria-role": 0,
-      "jsx-a11y/aria-props": 0,
-      "jsx-a11y/aria-proptypes": 0,
-      "jsx-a11y/aria-unsupported-elements": 0,
-      "jsx-a11y/alt-text": 0,
-      "jsx-a11y/img-redundant-alt": 0,
-      "jsx-a11y/label-has-for": 0,
-      "jsx-a11y/label-has-associated-control": 0,
-      "jsx-a11y/mouse-events-have-key-events": 0,
-      "jsx-a11y/no-access-key": 0,
-      "jsx-a11y/no-onchange": 0,
-      "jsx-a11y/interactive-supports-focus": 0,
-      "jsx-a11y/role-has-required-aria-props": 0,
-      "jsx-a11y/role-supports-aria-props": 0,
-      "jsx-a11y/tabindex-no-positive": 0,
-      "jsx-a11y/heading-has-content": 0,
-      "jsx-a11y/html-has-lang": 0,
-      "jsx-a11y/lang": 0,
-      "jsx-a11y/no-distracting-elements": 0,
-      "jsx-a11y/scope": 0,
-      "jsx-a11y/click-events-have-key-events": 0,
-      "jsx-a11y/no-static-element-interactions": 0,
-      "jsx-a11y/no-noninteractive-element-interactions": 0,
-      "jsx-a11y/accessible-emoji": 0,
-      "jsx-a11y/aria-activedescendant-has-tabindex": 0,
-      "jsx-a11y/iframe-has-title": 0,
-      "jsx-a11y/no-autofocus": 0,
-      "jsx-a11y/no-redundant-roles": 0,
-      "jsx-a11y/media-has-caption": 0,
-      "jsx-a11y/no-interactive-element-to-noninteractive-role": 0,
-      "jsx-a11y/no-noninteractive-element-to-interactive-role": 0,
-      "jsx-a11y/no-noninteractive-tabindex": 0,
-      "jsx-a11y/anchor-is-valid": 0,
       "react/jsx-one-expression-per-line": 0,
 
       // Warnings

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eslint": "5.4.0",
     "eslint-config-airbnb": "17.1.0",
     "eslint-plugin-import": "2.14.0",
-    "eslint-plugin-jsx-a11y": "6.1.1",
+    "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-no-only-tests": "2.4.0",
     "eslint-plugin-react": "7.11.1"
   },
@@ -18,7 +18,7 @@
     "eslint": "5.4.0",
     "eslint-config-airbnb": "17.1.0",
     "eslint-plugin-import": "2.14.0",
-    "eslint-plugin-jsx-a11y": "6.1.1",
+    "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-react": "7.11.1"
   }
 }


### PR DESCRIPTION
Since we're now investing in accessibility, it's time we enable the a11y rules that come with `eslint-jsx-a11y-plugin`.

This might slow us down at first, and might not make sense, we can change each rule as we go along.
But we need to have a better mindset when it comes to accessibility.

You can find the list of rules from the `recommended` list [here](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/066ccffac37459e5b3dcb607f06ad3e88bc39c08/src/index.js#L52-L197)